### PR TITLE
Fix Travis CI Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.5"
 before_install:
   - mv travis_secrets.yaml secrets.yaml
+  - mv travis_zones.yaml zones.yaml
   - sudo apt-get install -y libudev-dev
 install:
   - pip3 install homeassistant

--- a/travis_secrets.yaml
+++ b/travis_secrets.yaml
@@ -32,10 +32,10 @@ gmusic_device_id: apikey
 latitude: 0
 longitude: 0
 elevation: 0
-isy_host: host
+isy_host: http://127.0.0.1
 elk_host: host
 zm_host: host
 unifi_host: host
-unifi_port: port
+unifi_port: 1
 den_kodi_host: host
 roomba_host: host


### PR DESCRIPTION
Test was failing due to a missing zones.yaml file.  Created blank travis_zones.yaml file and added command to .travis.yml to rename it to zones.yaml.  Updated travis_secrets.yaml to provide "valid" credentials.