### PR TITLE
Add GitHub and Travis CI Sensors

### DIFF
--- a/packages/github_integration.yaml
+++ b/packages/github_integration.yaml
@@ -1,0 +1,9 @@
+#Components needed for GitHub repository and Travis CI monitoring.
+sensor:
+  - platform: github
+    access_token: !secret github_access_token
+    repositories:
+      - path: '/config'
+  - platform: travisci
+    api_key: !secret travis_access_token
+    branch: dev

--- a/travis_secrets.yaml
+++ b/travis_secrets.yaml
@@ -39,3 +39,5 @@ unifi_host: host
 unifi_port: 1
 den_kodi_host: host
 roomba_host: host
+github_access_token: token
+travis_access_token: token


### PR DESCRIPTION
Add sensors to monitor repository and build status.  Groundwork for
updating HA from UI.