### PR TITLE
Fix Toast Notification Bug

### DIFF
--- a/automation/laundry.yaml
+++ b/automation/laundry.yaml
@@ -156,6 +156,7 @@
     - service: browser_mod.toast
       data:
         message: "The dryer has stopped."
+        duration: 3000
 
 - alias: "Repeat Announce Dryer Finished"
   id: a51c8c5c-31af-4001-b931-5125204164cc
@@ -225,6 +226,7 @@
     - service: browser_mod.toast
       data:
         message: "The washer has stopped."
+        duration: 3000
 
 - alias: "Repeat Announce Washer Finished"
   id: 7eef5299-bafb-4bbb-9da0-0d72952edb03

--- a/automation/rain_gauge.yaml
+++ b/automation/rain_gauge.yaml
@@ -120,6 +120,7 @@
     - service: browser_mod.toast
       data:
         message: "It is now raining."
+        duration: 3000
 
 - alias: Detect Rain Stopped
   id: 9ae2b245-b303-4d59-ba85-2be41146bcdd
@@ -148,6 +149,7 @@
     - service: browser_mod.toast
       data:
         message: "It has stopped raining."
+        duration: 3000
 
 - alias: Display Rainfall on Elk Keypads
   id: aae69df9-96b8-4b41-aac4-ddbc2f3e37db

--- a/automation/speech.yaml
+++ b/automation/speech.yaml
@@ -336,6 +336,7 @@
     - service: browser_mod.toast
       data:
         message: "Someone is at the door."
+        duration: 3000
     - service: notify.cctv_email
       data_template:
         title: "CCTV Alarm: Front Porch - Doorbell Pressed {{now().strftime('%Y-%m-%d %H:%M:%S') }}"


### PR DESCRIPTION
# Proposed Changes

Add duration entry to toast notifications to auto-close them as intended.

## Related Issues

#563 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
