### PR TITLE
Move Thermopile Sensor to MQTT

### DIFF
--- a/packages/water_heater.yaml
+++ b/packages/water_heater.yaml
@@ -1,4 +1,9 @@
 sensor:
+  - platform: mqtt
+    name: Thermopile Voltage
+    state_topic: hwh_mon/sensor/thermopile_voltage/state
+    icon: mdi:flame
+    
   - platform: template
     sensors:
       water_heater_status:


### PR DESCRIPTION
# Proposed Changes

Move the thermopile sensor from ESPHome integration to MQTT due to stability issues

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
