### PR TITLE
Change Roomba Docking Trigger

### DIFF
--- a/automation/roomba.yaml
+++ b/automation/roomba.yaml
@@ -22,9 +22,9 @@
 - alias: Roomba Return if House Disarmed
   id: 6dba1760-613c-4165-8e41-b54466b7ff1d
   trigger:
-    - entity_id: alarm_control_panel.house
-      platform: state
-      to: disarmed
+    - platform: state
+      entity_id: input_boolean.hvac_geofence
+      to: "on"
   condition:
     - condition: state
       entity_id: sensor.roomba_status


### PR DESCRIPTION
Roomba will now return to dock when geofence is entered instead of when house is disarmed.

# Proposed Changes

Change automation trigger from alarm to geofence.

## Related Issues



[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
