### PR TITLE
Add Aruba Device Tracker

### DIFF
--- a/.stubs/secrets.yaml
+++ b/.stubs/secrets.yaml
@@ -224,3 +224,8 @@ webhook_build_pending: 000
 webhook_build_running: 000
 webhook_build_failing: 000
 webhook_build_passing: 000
+
+#Aruba IAP
+aruba_host: 127.0.0.1
+aruba_user: user
+aruba_pass: pass

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -354,3 +354,10 @@ input_select:
     icon: mdi:music
 
 circadian_lighting:
+
+# Example configuration.yaml entry
+device_tracker:
+  - platform: aruba
+    host: !secret aruba_host
+    username: !secret aruba_user
+    password: !secret aruba_pass


### PR DESCRIPTION
# Proposed Changes

Testing the Aruba device tracker for use with new IAP-207 APs.

## Related Issues


[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
