### PR TITLE
Update Christmas Devices and UI

### DIFF
--- a/lovelace/cards/rooms/christmas.yaml
+++ b/lovelace/cards/rooms/christmas.yaml
@@ -30,137 +30,24 @@ card:
           name: Indoor
           hold_action:
             action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.christmas_tree
+        
+        - type: custom:button-card
+          entity: sensor.candle_dummy
           color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Tree
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.christmas_garland
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Garland
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.christmas_village
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Village
-          hold_action:
-            action: more-info
-
-    - type: horizontal-stack
-      cards:
-        - type: "custom:button-card"
-          entity: switch.dining_room_decor
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Dining
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.entry_hall_decor
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Entry
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.master_bedroom_decor
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Master
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.snowman
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Snow Man
-          hold_action:
-            action: more-info
-    - type: horizontal-stack
-      cards:
-        - type: "custom:button-card"
-          entity: switch.kitchen_garland
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Kitchen
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.hall_decor
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Hall
-          hold_action:
-            action: more-info
-
-        - type: "custom:button-card"
-          entity: switch.office_decor
-          color_type: icon
-          color: rgb(228, 94, 101)
-          state:
-            - value: "on"
-              icon: mdi:string-lights
-            - value: "off"
-              icon: mdi:string-lights-off
-          name: Office
+          icon: mdi:candle
+          name: Candles
+          tap_action:
+            action: call-service
+            service: mqtt.publish
+            service_data:
+              topic: ir/all/cmnd/irsend
+              payload: '{"Protocol":"NEC","Bits":32,"Data":"0x1FE48B7"}'
+          double_tap_action:
+            action: call-service
+            service: mqtt.publish
+            service_data:
+              topic: ir/all/cmnd/irsend
+              payload: '{"Protocol":"NEC","Bits":32,"Data":"0x1FE58A7"}'
           hold_action:
             action: more-info
 
@@ -173,21 +60,15 @@ card:
           tap_action:
             action: more-info
 
-    # - type: horizontal-stack
-    #   cards:
-
-    #     - type: "custom:button-card"
-    #       entity: input_boolean.donation_box
-    #       color_type: icon
-    #       color: rgb(228, 94, 101)
-    #       state:
-    #         - value: "on"
-    #           icon: mdi:door-open
-    #         - value: "off"
-    #           icon: mdi:door-closed
-    #       name: Donation
-    #       hold_action:
-    #         action: more-info
-
-    #     - type: custom:gap-card
-    #     - type: custom:gap-card
+        - type: "custom:button-card"
+          entity: input_boolean.donation_box
+          color_type: icon
+          color: rgb(228, 94, 101)
+          state:
+            - value: "on"
+              icon: mdi:door-open
+            - value: "off"
+              icon: mdi:door-closed
+          name: Donation
+          hold_action:
+            action: more-info

--- a/lovelace/cards/rooms/hall.yaml
+++ b/lovelace/cards/rooms/hall.yaml
@@ -23,6 +23,7 @@ cards:
         type: state-label
   - type: horizontal-stack
     cards:
+      - type: "custom:gap-card"
       - type: "custom:button-card"
         entity: light.hallway_light
         color_type: icon
@@ -33,25 +34,6 @@ cards:
           - value: "off"
             icon: mdi:lightbulb-outline
         name: Light
-        hold_action:
-          action: more-info
-      - type: custom:button-card
-        entity: sensor.candle_dummy
-        color_type: icon
-        icon: mdi:candle
-        name: Candles
-        tap_action:
-          action: call-service
-          service: mqtt.publish
-          service_data:
-            topic: ir/all/cmnd/irsend
-            payload: '{"Protocol":"NEC","Bits":32,"Data":"0x1FE48B7"}'
-        double_tap_action:
-          action: call-service
-          service: mqtt.publish
-          service_data:
-            topic: ir/all/cmnd/irsend
-            payload: '{"Protocol":"NEC","Bits":32,"Data":"0x1FE58A7"}'
         hold_action:
           action: more-info
       - type: "custom:button-card"

--- a/lovelace/popup/popup_rooms.yaml
+++ b/lovelace/popup/popup_rooms.yaml
@@ -10,6 +10,36 @@ input_boolean.christmas_show:
         name: Playlist Section
       - entity: sensor.fpp_master_sequence
         name: Sequence
+      - entity: switch.christmas_amplifier
+        name: Amplifier
+      - entity: switch.christmas_security_lights
+        name: Security Lights
+
+switch.indoor_christmas:
+  title: Indoor Christmas
+  card:
+    type: entities
+    entities:
+      - entity: switch.christmas_tree
+        name: Tree
+      - entity: switch.christmas_garland
+        name: Garland
+      - entity: switch.christmas_village
+        name: Villiage
+      - entity: switch.dining_room_decor
+        name: Dining
+      - entity: switch.entry_hall_decor
+        name: Entry
+      - entity: switch.master_bedroom_decor
+        name: Master
+      - entity: switch.snowman
+        name: Snow Man
+      - entity: switch.kitchen_garland
+        name: Kitchen
+      - entity: switch.hall_decor
+        name: Hall
+      - entity: switch.office_decor
+        name: Office
 
 cover.den_blinds:
   title: Den Blinds

--- a/packages/christmas.yaml
+++ b/packages/christmas.yaml
@@ -109,6 +109,28 @@ switch:
     payload_available: "Online"
     payload_not_available: "Offline"
 
+  - platform: mqtt
+    name: "Christmas Amplifier"
+    state_topic: "christmas/outdoon/amplifier/stat/POWER"
+    command_topic: "christmas/outdoon/amplifiere/cmnd/POWER"
+    availability_topic: "christmas/outdoon/amplifier/tele/LWT"
+    qos: 1
+    payload_on: "ON"
+    payload_off: "OFF"
+    payload_available: "Online"
+    payload_not_available: "Offline"
+
+  - platform: mqtt
+    name: "Christmas Security Lights"
+    state_topic: "christmas/outdoor/security/stat/POWER"
+    command_topic: "christmas/outdoor/security/cmnd/POWER"
+    availability_topic: "christmas/outdoor/security/tele/LWT"
+    qos: 1
+    payload_on: "ON"
+    payload_off: "OFF"
+    payload_available: "Online"
+    payload_not_available: "Offline"
+
   - platform: template
     switches:
       indoor_christmas:
@@ -222,6 +244,26 @@ sensor:
     unit_of_measurement: "%"
     value_template: "{{value_json['Wifi'].RSSI }}"
     availability_topic: "christmas/indoor/office/tele/LWT"
+    qos: 1
+    payload_available: "Online"
+    payload_not_available: "Offline"
+
+  - platform: mqtt
+    state_topic: "christmas/outdoor/amplifier/tele/STATE"
+    name: "Christmas Amplifier Signal"
+    unit_of_measurement: "%"
+    value_template: "{{value_json['Wifi'].RSSI }}"
+    availability_topic: "christmas/outdoor/amplifier/tele/LWT"
+    qos: 1
+    payload_available: "Online"
+    payload_not_available: "Offline"
+
+  - platform: mqtt
+    state_topic: "christmas/outdoor/security/tele/STATE"
+    name: "Christmas Security Lights Signal"
+    unit_of_measurement: "%"
+    value_template: "{{value_json['Wifi'].RSSI }}"
+    availability_topic: "christmas/outdoor/security/tele/LWT"
     qos: 1
     payload_available: "Online"
     payload_not_available: "Offline"


### PR DESCRIPTION
# Proposed Changes

Add new switches for amplifier and security lights for Christmas show.  This migrates devices from DMX relay packs to MQTT relays.  Also streamlined the Christmas Lovelace card.

