### PR TITLE
Update Prusa Offline Condition

### DIFF
--- a/lovelace/views/settings.yaml
+++ b/lovelace/views/settings.yaml
@@ -422,7 +422,7 @@ cards:
       - type: conditional
         conditions:
           - entity: sensor.prusa_mk3_current_state
-            state: "unknown"
+            state: "unavailable"
         card:
           type: picture-elements
           image: /local/lovelace/room.png
@@ -441,7 +441,7 @@ cards:
       - type: conditional
         conditions:
           - entity: sensor.prusa_mk3_current_state
-            state_not: "unknown"
+            state_not: "unavailable"
         card:
           type: "custom:vertical-stack-in-card"
           cards:


### PR DESCRIPTION
# Proposed Changes

Octoprint has changed from Unknown to Unavailable when the printer is disconnected.  Changing the conditions to hide the card when offline.  As the Octoprint integration no longer provides temperature data and uses a different time reporting scheme, these fields will need updating as well.

