### PR TITLE
Migrate to Stack-in-Card

### DIFF
--- a/lovelace/cards/rooms/christmas.yaml
+++ b/lovelace/cards/rooms/christmas.yaml
@@ -6,7 +6,7 @@ conditions:
   - entity: switch.christmas_tree
     state_not: "unknown"
 card:
-  type: custom:vertical-stack-in-card
+  type: custom:stack-in-card
   cards:
     - type: picture-elements
       image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/den.yaml
+++ b/lovelace/cards/rooms/den.yaml
@@ -1,5 +1,5 @@
 # Den
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/entry.yaml
+++ b/lovelace/cards/rooms/entry.yaml
@@ -1,5 +1,5 @@
 # Entry
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/garage.yaml
+++ b/lovelace/cards/rooms/garage.yaml
@@ -1,5 +1,5 @@
 # Garage
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/guest_bath.yaml
+++ b/lovelace/cards/rooms/guest_bath.yaml
@@ -1,5 +1,5 @@
 # Guest Bathroom
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/guest_bed.yaml
+++ b/lovelace/cards/rooms/guest_bed.yaml
@@ -1,5 +1,5 @@
 # Guest Bedroom
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/hall.yaml
+++ b/lovelace/cards/rooms/hall.yaml
@@ -1,5 +1,5 @@
 # Front Hall
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/kitchen.yaml
+++ b/lovelace/cards/rooms/kitchen.yaml
@@ -1,5 +1,5 @@
 # Kitchen
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/master_bath.yaml
+++ b/lovelace/cards/rooms/master_bath.yaml
@@ -1,5 +1,5 @@
 # Master Bathroom
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/master_bed.yaml
+++ b/lovelace/cards/rooms/master_bed.yaml
@@ -1,5 +1,5 @@
 # Master Bedroom
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/office.yaml
+++ b/lovelace/cards/rooms/office.yaml
@@ -1,5 +1,5 @@
 # Office
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/outside.yaml
+++ b/lovelace/cards/rooms/outside.yaml
@@ -1,5 +1,5 @@
 # Outside
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/server.yaml
+++ b/lovelace/cards/rooms/server.yaml
@@ -1,5 +1,5 @@
 # Server Room
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/shack.yaml
+++ b/lovelace/cards/rooms/shack.yaml
@@ -1,5 +1,5 @@
 # Shack
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/utility.yaml
+++ b/lovelace/cards/rooms/utility.yaml
@@ -1,5 +1,5 @@
 # Laundry
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/rooms/work.yaml
+++ b/lovelace/cards/rooms/work.yaml
@@ -1,5 +1,5 @@
 # Work
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: picture-elements
     image: /local/lovelace/room_sm.png

--- a/lovelace/cards/thermostat/front.yaml
+++ b/lovelace/cards/thermostat/front.yaml
@@ -1,5 +1,5 @@
 #Front Rooms HVAC Card
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: custom:simple-thermostat
     entity: climate.front_rooms

--- a/lovelace/cards/thermostat/living.yaml
+++ b/lovelace/cards/thermostat/living.yaml
@@ -1,6 +1,6 @@
 #Living Areas HVAC Card
 
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: custom:simple-thermostat
     entity: climate.living_areas

--- a/lovelace/cards/thermostat/master.yaml
+++ b/lovelace/cards/thermostat/master.yaml
@@ -1,6 +1,6 @@
 #Master Suite HVAC Card
 
-type: custom:vertical-stack-in-card
+type: custom:stack-in-card
 cards:
   - type: custom:simple-thermostat
     entity: climate.master_suite

--- a/lovelace/popup/popup_panel_master.yaml
+++ b/lovelace/popup/popup_panel_master.yaml
@@ -89,7 +89,7 @@ cover.master_blinds:
 input_boolean.work_alarm_enabled:
   title: Work Alarm
   card:
-    type: custom:vertical-stack-in-card
+    type: custom:stack-in-card
     cards:
       - type: entities
         show_header_toggle: false
@@ -118,7 +118,7 @@ input_boolean.work_alarm_enabled:
 input_boolean.manual_alarm_enabled:
   title: Manual Alarm Clock
   card:
-    type: custom:vertical-stack-in-card
+    type: custom:stack-in-card
     cards:
       - type: horizontal-stack
         cards:

--- a/lovelace/popup/popup_rooms.yaml
+++ b/lovelace/popup/popup_rooms.yaml
@@ -1443,7 +1443,7 @@ cover.master_blinds:
 input_boolean.work_alarm_enabled:
   title: Work Alarm
   card:
-    type: custom:vertical-stack-in-card
+    type: custom:stack-in-card
     cards:
       - type: entities
         show_header_toggle: false
@@ -1472,7 +1472,7 @@ input_boolean.work_alarm_enabled:
 input_boolean.manual_alarm_enabled:
   title: Manual Alarm Clock
   card:
-    type: custom:vertical-stack-in-card
+    type: custom:stack-in-card
     cards:
       - type: horizontal-stack
         cards:

--- a/lovelace/views/hvac.yaml
+++ b/lovelace/views/hvac.yaml
@@ -16,7 +16,7 @@ cards:
   #################################################################
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         title: System
         cards:
           - type: horizontal-stack

--- a/lovelace/views/media.yaml
+++ b/lovelace/views/media.yaml
@@ -34,7 +34,7 @@ cards:
               progress: true
               name: true
 
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -230,7 +230,7 @@ cards:
                 info: true
                 progress: true
 
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png

--- a/lovelace/views/settings.yaml
+++ b/lovelace/views/settings.yaml
@@ -14,7 +14,7 @@ popup_cards:
 cards:
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -391,7 +391,7 @@ cards:
   - type: vertical-stack
     cards:
       - !include /config/lovelace/cards/rooms/work.yaml
-      - type: 'custom:vertical-stack-in-card'
+      - type: 'custom:stack-in-card'
         cards:
           - type: picture-elements
             image: /local/lovelace/room_sm.png
@@ -443,7 +443,7 @@ cards:
           - entity: sensor.prusa_mk3_current_state
             state_not: "unavailable"
         card:
-          type: "custom:vertical-stack-in-card"
+          type: "custom:stack-in-card"
           cards:
             - type: picture-elements
               image: /local/lovelace/room.png

--- a/lovelace/views/system.yaml
+++ b/lovelace/views/system.yaml
@@ -18,7 +18,7 @@ cards:
 
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: custom:mini-graph-card
             entities:
@@ -159,7 +159,7 @@ cards:
       #                                                               #
       #################################################################
 
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -187,7 +187,7 @@ cards:
             cards:
               - type: horizontal-stack
                 cards:
-                  - type: custom:vertical-stack-in-card
+                  - type: custom:stack-in-card
                     cards:
                       - type: custom:bar-card
                         name: Disk
@@ -303,7 +303,7 @@ cards:
                             display: none;
                           }
 
-                  - type: custom:vertical-stack-in-card
+                  - type: custom:stack-in-card
                     cards:
                       - type: custom:bar-card
                         name: CPU
@@ -425,7 +425,7 @@ cards:
       #                                                               #
       #################################################################
 
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -1236,7 +1236,7 @@ cards:
   #################################################################
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -1329,7 +1329,7 @@ cards:
                 hold_action:
                   action: more-info
 
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -1670,7 +1670,7 @@ cards:
 
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png

--- a/lovelace/views/utilities.yaml
+++ b/lovelace/views/utilities.yaml
@@ -12,7 +12,7 @@ popup_cards:
 cards:
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png
@@ -209,7 +209,7 @@ cards:
 
   - type: vertical-stack
     cards:
-      - type: custom:vertical-stack-in-card
+      - type: custom:stack-in-card
         cards:
           - type: picture-elements
             image: /local/lovelace/room.png


### PR DESCRIPTION
# Proposed Changes

Vertical-stack-in-card cards have always had square corners if using a picture element for the banner.  stack-in-card resolves this issue.