### PR TITLE
Handle Default Elapsed When Not Printing

### DIFF
--- a/packages/octoprint.yaml
+++ b/packages/octoprint.yaml
@@ -21,34 +21,38 @@ sensor:
 
       elapsed_print_time:
         value_template: >-
-          {% set time = as_timestamp(now(),0) - as_timestamp(states('sensor.prusa_mk3_start_time'),0) %}
-            {% set minutes = ((time / 60) % 60) | int(none)%}
-            {% set hours = (time / 3600) | int(none) %}
-              {%- if time < 60-%}
-                00:00
-              {%- else -%}
-              {%- if hours == 0 -%}
-                00
-              {%- endif -%}
-              {%- if hours > 0 -%}
-            
-                {%- if hours < 10 -%}
-                  0{{ hours }}
+          {%- if not is_state('sensor.prusa_mk3_start_time','unknown') %}
+            {% set time = as_timestamp(now(),0) - as_timestamp(states('sensor.prusa_mk3_start_time'),0) %}
+              {% set minutes = ((time / 60) % 60) | int(none)%}
+              {% set hours = (time / 3600) | int(none) %}
+                {%- if time < 60-%}
+                  00:00
                 {%- else -%}
-                  {{ hours }}
+                {%- if hours == 0 -%}
+                  00
                 {%- endif -%}
-              {%- endif -%}
-              {%- if minutes == 0 -%}
-                :00
-              {%- endif -%}
-              {%- if minutes > 0 -%}
-                {%- if minutes < 10 -%}
-                  :0{{ minutes }}
-                {%- else -%}
-                  :{{ minutes }}
+                {%- if hours > 0 -%}
+              
+                  {%- if hours < 10 -%}
+                    0{{ hours }}
+                  {%- else -%}
+                    {{ hours }}
+                  {%- endif -%}
                 {%- endif -%}
-              {%- endif -%}
-              {%- endif -%}
+                {%- if minutes == 0 -%}
+                  :00
+                {%- endif -%}
+                {%- if minutes > 0 -%}
+                  {%- if minutes < 10 -%}
+                    :0{{ minutes }}
+                  {%- else -%}
+                    :{{ minutes }}
+                  {%- endif -%}
+                {%- endif -%}
+                {%- endif -%}
+          {%- else %}
+            0:00
+          {%- endif -%}
 
       remaining_print_time:
         value_template: >-


### PR DESCRIPTION
# Proposed Changes

With the changes to Octoprint's remaining and elapsed time display, a re-write of the time sensors was written.  Unfortunately, this did not properly handle showing 0:00 elapsed when no print was running.  This change fixes that.