### PR TITLE
Update Spotify Endpoint

### DIFF
--- a/packages/spotify.yaml
+++ b/packages/spotify.yaml
@@ -147,7 +147,7 @@ script:
       - service: media_player.select_source
         data:
           entity_id: media_player.spotify_home
-          source: "Shawn's Echo Dot"
+          source: "raspotify (raspotify)"
       - service: media_player.media_play
         entity_id: media_player.spotify_home
       - service: homeassistant.update_entity


### PR DESCRIPTION
# Proposed Changes

Change audio endpoint from Echo Dot to Raspotify.  This is in an effort to stop the looping of 5 songs that the Echo does on occasion.
