### PR TITLE
Add Camera Aspect Ratio

### DIFF
--- a/lovelace/views/settings.yaml
+++ b/lovelace/views/settings.yaml
@@ -1101,3 +1101,4 @@ cards:
               camera_view: live
               show_name: false
               show_state: false
+              aspect_ratio: 4x3


### PR DESCRIPTION
# Proposed Changes

Add aspect ratio to Prusa camera display.  Camera is 4:3, but HA defaults to 16:9.