### PR TITLE
Add Template Sensors to Buffer Wind Data

### DIFF
--- a/packages/climate_weather/climate_weather.yaml
+++ b/packages/climate_weather/climate_weather.yaml
@@ -284,6 +284,7 @@ sensor:
 template:
   - sensor:
     - name: AcuRite Atlas Wind Speed Buffered
+      unique_id: bb04804b-cad8-4bda-9124-e249215761aa
       unit_of_measurement: "mph"
       device_class: wind_speed
       state_class: measurement
@@ -291,6 +292,7 @@ template:
       attributes:
           minute_counter: "{{ now().minute }}"
     - name: AcuRite Atlas Wind Direction Buffered
+      unique_id: f220269c-ee0b-4024-bc93-d74b4ed7cdf7
       unit_of_measurement: "°"
       state_class: measurement
       state: "{{ states('sensor.acurite_atlas_wind_direction') }}"

--- a/packages/climate_weather/climate_weather.yaml
+++ b/packages/climate_weather/climate_weather.yaml
@@ -260,7 +260,7 @@ sensor:
   - platform: statistics
     name: Local Wind Gust 10 Minute
     unique_id: 717aeaac-2fa1-48db-96e7-b151be95f843
-    entity_id: sensor.acurite_atlas_wind_speed
+    entity_id: sensor.acurite_atlas_wind_speed_buffered
     state_characteristic: value_max
     max_age:
       minutes: 10
@@ -276,10 +276,28 @@ sensor:
   - platform: statistics
     name: Local Wind Direction 2 Minute Average
     unique_id: a9dd1b0c-f51f-40cd-9846-3a7a30b69cf5
-    entity_id: sensor.acurite_atlas_wind_direction
+    entity_id: sensor.acurite_atlas_wind_direction_buffered
     state_characteristic: mean
     max_age:
       minutes: 2
+
+template:
+  - sensor:
+    - name: AcuRite Atlas Wind Speed Buffered
+      unit_of_measurement: "mph"
+      device_class: wind_speed
+      state_class: measurement
+      state: "{{ states('sensor.acurite_atlas_wind_speed') }}"
+      attributes:
+          minute_counter: "{{ now().minute }}"
+    - name: AcuRite Atlas Wind Direction Buffered
+      unit_of_measurement: "°"
+      state_class: measurement
+      state: "{{ states('sensor.acurite_atlas_wind_direction') }}"
+      attributes:
+          minute_counter: "{{ now().minute }}"
+
+
 
 mqtt:
   sensor:


### PR DESCRIPTION
# Proposed Changes

Wind statistics sensors will report as 'unknown' when conditions have not changed for the duration of the lookback window.  Add buffering to force updates.  

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
https://github.com/home-assistant/core/issues/67627
