### PR TITLE
Add Sound Machine Via Android

### DIFF
--- a/.stubs/secrets.yaml
+++ b/.stubs/secrets.yaml
@@ -9,6 +9,7 @@ ar_lock_truck: http://127.0.0.1
 ar_start_truck: http://127.0.0.1
 ar_stop_truck: http://127.0.0.1
 ar_unlock_truck: http://127.0.0.1
+ar_play_waves: http://127.0.0.1
 aruba_host: 127.0.0.1
 aruba_pass: pass
 aruba_user: user

--- a/automation/alexa_routines.yaml
+++ b/automation/alexa_routines.yaml
@@ -18,6 +18,7 @@
       entity_id: light.master_suite_leds_rgb
     - service: switch.turn_off
       entity_id: switch.master_bedroom_lamps
+    - service: rest_command.play_waves
     - service: input_boolean.turn_off
       entity_id: input_boolean.goodnight_trigger
 
@@ -43,6 +44,7 @@
       entity_id: switch.master_bedroom_lamps
     - service: switch.turn_on
       entity_id: switch.elk_night_mode_on
+    - service: rest_command.play_waves
     - service: input_boolean.turn_off
       entity_id: input_boolean.goodnight_trigger
 
@@ -72,6 +74,7 @@
       data:
         topic: nuvo/command/set/zone/vol
         payload: 4,60
+    - service: rest_command.play_waves
     - service: switch.turn_off
       entity_id: switch.master_bedroom_fan
     - service: light.turn_off

--- a/packages/autoremote.yaml
+++ b/packages/autoremote.yaml
@@ -9,3 +9,5 @@ rest_command:
     url: !secret ar_stop_truck
   load_audiobook:
     url: !secret ar_load_audiobook
+  play_waves:
+    url: !secret ar_play_waves


### PR DESCRIPTION
# Proposed Changes

With the demise of the Sound Machine Alexa skill, use AutoRemote to trigger Atmosphere on an old Android phone instead.
