### PR TITLE
Update Failover Logic

### DIFF
--- a/packages/climate_weather/climate_weather.yaml
+++ b/packages/climate_weather/climate_weather.yaml
@@ -1452,7 +1452,7 @@ automation:
     condition:
       - condition: state
         entity_id: input_boolean.atlas_bad
-        state: "on"
+        state: "off"
     action:
       - service: timer.start
         entity_id: timer.atlas_watchdog      


### PR DESCRIPTION
# Proposed Changes

Failover timer for AcuRite was set to start on boot if the unit showed failed when last running.  This logic is backwards as the timer is stopped when failed.  The timer only runs when the sensor is reporting as it is a report watchdog and therefore needs to be restarted at boot.
