### PR TITLE
Change Snapshot Method, Front Camera Control

### DIFF
--- a/packages/cctv.yaml
+++ b/packages/cctv.yaml
@@ -48,6 +48,14 @@ timer:
 
 shell_command:
   clear_temp_images: bash /config/bin/clean_up_temp_images.sh
+  west_front_snapshot: 'wget -q 10.10.10.28:5000/api/west_front/any/snapshot.jpg -O /config/www/cctv/west_front.jpg'
+  east_front_snapshot: 'wget -q 10.10.10.28:5000/api/east_front/any/snapshot.jpg -O /config/www/cctv/east_front.jpg'
+  west_side_snapshot: 'wget -q 10.10.10.28:5000/api/west_side/any/snapshot.jpg -O /config/www/cctv/west_side.jpg'
+  east_side_snapshot: 'wget -q 10.10.10.28:5000/api/east_side/any/snapshot.jpg -O /config/www/cctv/east_side.jpg'
+  back_yard_snapshot: 'wget -q 10.10.10.28:5000/api/back_yard/any/snapshot.jpg -O /config/www/cctv/back_yard.jpg'
+  back_porch_snapshot: 'wget -q 10.10.10.28:5000/api/back_porch/any/snapshot.jpg -O /config/www/cctv/back_porch.jpg'
+  front_porch_snapshot: 'wget -q 10.10.10.28:5000/api/front_porch/any/snapshot.jpg -O /config/www/cctv/front_porch.jpg'
+  garage_snapshot: 'wget -q 10.10.10.28:5000/api/garage/any/snapshot.jpg -O /config/www/cctv/garage.jpg'
 
 automation:
   - alias: CCTV West Front Person Detected
@@ -64,28 +72,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.west_front
-          filename: /config/www/cctv/west_front_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.west_front_person
-          filename: /config/www/cctv/west_front_person.jpg
+      - service: shell_command.west_front_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: West Front - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the west front camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/west_front_person.jpg
-              - /config/www/cctv/west_front_full.jpg
+              - /config/www/cctv/west_front.jpg
             html: >
               A person was detected on the west front camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:west_front_person.jpg">
-              <br>
-              <img src="cid:west_front_full.jpg">
+              <img src="cid:west_front.jpg">
 
   - alias: CCTV East Front Person Detected
     id: 0575e725-ee28-48b4-a16d-c1abd1d5df62
@@ -101,28 +99,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.east_front
-          filename: /config/www/cctv/east_front_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.east_front_person
-          filename: /config/www/cctv/east_front_person.jpg
+      - service: shell_command.east_front_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: East Front - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the east front camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/east_front_person.jpg
-              - /config/www/cctv/east_front_full.jpg
+              - /config/www/cctv/east_front.jpg
             html: >
               A person was detected on the east front camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:east_front_person.jpg">
-              <br>
-              <img src="cid:east_front_full.jpg">
+              <img src="cid:east_front.jpg">
 
   - alias: CCTV West Side Person Detected
     id: 4be4a812-c669-4bb4-a93d-61c838953e73
@@ -138,28 +126,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.west_side
-          filename: /config/www/cctv/west_side_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.west_side_person
-          filename: /config/www/cctv/west_side_person.jpg
+      - service: shell_command.west_side_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: West Side - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the west side camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/west_side_person.jpg
-              - /config/www/cctv/west_side_full.jpg
+              - /config/www/cctv/west_side.jpg
             html: >
               A person was detected on the west side camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:west_side_person.jpg">
-              <br>
-              <img src="cid:west_side_full.jpg">
+              <img src="cid:west_side.jpg">
 
   - alias: CCTV East Side Person Detected
     id: d6ba9ca2-2ec0-4ef4-8b6a-d8af97842a3f
@@ -175,28 +153,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.east_side
-          filename: /config/www/cctv/east_side_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.east_side_person
-          filename: /config/www/cctv/east_side_person.jpg
+      - service: shell_command.east_side_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: East Side - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the east side camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/east_side_person.jpg
-              - /config/www/cctv/east_side_full.jpg
+              - /config/www/cctv/east_side.jpg
             html: >
               A person was detected on the east side camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:east_side_person.jpg">
-              <br>
-              <img src="cid:east_side_full.jpg">
+              <img src="cid:east_side.jpg">
 
   - alias: CCTV Back Yard Person Detected
     id: 8fb6c7cd-2915-45b3-83e2-3b12724ca6da
@@ -212,28 +180,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.back_yard
-          filename: /config/www/cctv/back_yard_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.back_yard_person
-          filename: /config/www/cctv/back_yard_person.jpg
+      - service: shell_command.back_yard_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Back Yard - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the back yard camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/back_yard_person.jpg
-              - /config/www/cctv/back_yard_full.jpg
+              - /config/www/cctv/back_yard.jpg
             html: >
               A person was detected on the back yaed camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:back_yard_person.jpg">
-              <br>
-              <img src="cid:back_yard_full.jpg">
+              <img src="cid:back_yard.jpg">
 
   - alias: CCTV Back Porch Person Detected
     id: 74430858-a2a9-45d7-b247-7f604ca3ecc6
@@ -249,28 +207,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.back_porch
-          filename: /config/www/cctv/back_porch_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.back_porch_person
-          filename: /config/www/cctv/back_porch_person.jpg
+      - service: shell_command.back_porch_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Back Porch - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the back porch camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/back_porch_person.jpg
-              - /config/www/cctv/back_porch_full.jpg
+              - /config/www/cctv/back_porch.jpg
             html: >
               A person was detected on the back porch camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:back_porch_person.jpg">
-              <br>
-              <img src="cid:back_porch_full.jpg">
+              <img src="cid:back_porch.jpg">
 
   - alias: CCTV Front Porch Person Detected
     id: 391c6db8-6e13-4650-a53c-374b69cccaa8
@@ -286,28 +234,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.front_porch
-          filename: /config/www/cctv/front_porch_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.front_porch_person
-          filename: /config/www/cctv/front_porch_person.jpg
+      - service: shell_command.front_porch_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Front Porch - Person Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A person was detected on the front porch camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/front_porch_person.jpg
-              - /config/www/cctv/front_porch_full.jpg
+              - /config/www/cctv/front_porch.jpg
             html: >
               A person was detected on the front porch camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:front_porch_person.jpg">
-              <br>
-              <img src="cid:front_porch_full.jpg">
+              <img src="cid:front_porch.jpg">
   
   - alias: CCTV Garage Person Detected
     id: d801733d-34e8-45b1-9c6d-be5adf1e553f
@@ -320,16 +258,7 @@ automation:
         entity_id: input_boolean.frigate_enabled
         state: 'on'
     action:
-      - service: camera.snapshot
-        continue_on_error: true
-        data:
-          entity_id: camera.garage
-          filename: /config/www/cctv/garage_full.jpg
-      - service: camera.snapshot
-        continue_on_error: true
-        data:
-          entity_id: image.garage_person
-          filename: /config/www/cctv/garage_person.jpg
+      - service: shell_command.garage_snapshot
       - service: notify.cctv_email
         continue_on_error: true
         data:
@@ -337,14 +266,11 @@ automation:
           message: "A person was detected on the garage camera at {{now().strftime('%H:%M:%S') }}."
           data: 
             images:
-              - /config/www/cctv/garage_person.jpg
-              - /config/www/cctv/garage_full.jpg
+              - /config/www/cctv/garage.jpg
             html: >
               A person was detected on the garage camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:garage_person.jpg">
-              <br>
-              <img src="cid:garage_full.jpg">
+              <img src="cid:garage.jpg">
   
   - alias: CCTV West Front Cat Detected
     id: b164b9bb-403e-444a-a299-4dce6c422074
@@ -360,28 +286,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.west_front
-          filename: /config/www/cctv/west_front_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.west_front_cat
-          filename: /config/www/cctv/west_front_cat.jpg
+      - service: shell_command.west_front_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: West Front - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the west front camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/west_front_cat.jpg
-              - /config/www/cctv/west_front_full.jpg
+              - /config/www/cctv/west_front.jpg
             html: >
               A cat was detected on the west front camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:west_front_cat.jpg">
-              <br>
-              <img src="cid:west_front_full.jpg">
+              <img src="cid:west_front.jpg">
 
   - alias: CCTV East Front Cat Detected
     id: 13294571-4be6-4bb8-9aa1-3a2e3080e71e
@@ -397,28 +313,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.east_front
-          filename: /config/www/cctv/east_front_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.east_front_cat
-          filename: /config/www/cctv/east_front_cat.jpg
+      - service: shell_command.east_front_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: East Front - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the east front camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/east_front_cat.jpg
-              - /config/www/cctv/east_front_full.jpg
+              - /config/www/cctv/east_front.jpg
             html: >
               A cat was detected on the east front camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:east_front_cat.jpg">
-              <br>
-              <img src="cid:east_front_full.jpg">
+              <img src="cid:east_front.jpg">
 
   - alias: CCTV West Side Cat Detected
     id: e408ca30-4591-424b-8bcb-184613b30408
@@ -434,28 +340,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.west_side
-          filename: /config/www/cctv/west_side_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.west_side_cat
-          filename: /config/www/cctv/west_side_cat.jpg
+      - service: shell_command.west_side_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: West Side - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the west side camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/west_side_cat.jpg
-              - /config/www/cctv/west_side_full.jpg
+              - /config/www/cctv/west_side.jpg
             html: >
               A cat was detected on the west side camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:west_side_cat.jpg">
-              <br>
-              <img src="cid:west_side_full.jpg">
+              <img src="cid:west_side.jpg">
 
   - alias: CCTV East Side Cat Detected
     id: 81df1be5-8263-48d8-b6fe-43da9662fb40
@@ -471,28 +367,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.east_side
-          filename: /config/www/cctv/east_side_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.east_side_cat
-          filename: /config/www/cctv/east_side_cat.jpg
+      - service: shell_command.east_side_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: East Side - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the east side camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/east_side_cat.jpg
-              - /config/www/cctv/east_side_full.jpg
+              - /config/www/cctv/east_side.jpg
             html: >
               A cat was detected on the east side camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:east_side_cat.jpg">
-              <br>
-              <img src="cid:east_side_full.jpg">
+              <img src="cid:east_side.jpg">
 
   - alias: CCTV Back Yard Cat Detected
     id: 88ff2d96-5855-4fbf-b1a9-ee2ba4b7b2d1
@@ -508,28 +394,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.back_yard
-          filename: /config/www/cctv/back_yard_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.back_yard_cat
-          filename: /config/www/cctv/back_yard_cat.jpg
+      - service: shell_command.back_yard_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Back Yard - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the back yard camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/back_yard_cat.jpg
-              - /config/www/cctv/back_yard_full.jpg
+              - /config/www/cctv/back_yard.jpg
             html: >
               A cat was detected on the back yard camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:back_yard_cat.jpg">
-              <br>
-              <img src="cid:back_yard_full.jpg">
+              <img src="cid:back_yard.jpg">
 
   - alias: CCTV Back Porch Cat Detected
     id: a2bb1489-ebd0-449e-a07e-c34202ee5056
@@ -545,28 +421,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_back
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.back_porch
-          filename: /config/www/cctv/back_porch_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.back_porch_cat
-          filename: /config/www/cctv/back_porch_cat.jpg
+      - service: shell_command.back_porch_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Back Porch - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the back porch camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/back_porch_cat.jpg
-              - /config/www/cctv/back_porch_full.jpg
+              - /config/www/cctv/back_porch.jpg
             html: >
               A cat was detected on the back porch camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:back_porch_cat.jpg">
-              <br>
-              <img src="cid:back_porch_full.jpg">
+              <img src="cid:back_porch.jpg">
 
   - alias: CCTV Front Porch Cat Detected
     id: 72662093-da18-46ac-b4b5-99763b2100ff
@@ -582,28 +448,18 @@ automation:
         entity_id: input_boolean.frigate_enabled_front
         state: "on"
     action:
-      - service: camera.snapshot
-        data:
-          entity_id: camera.front_porch
-          filename: /config/www/cctv/front_porch_full.jpg
-      - service: camera.snapshot
-        data:
-          entity_id: image.front_porch_cat
-          filename: /config/www/cctv/front_porch_cat.jpg
+      - service: shell_command.front_porch_snapshot
       - service: notify.cctv_email
         data:
           title: "CCTV Alarm: Front Porch - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the front porch camera at {{now().strftime('%H:%M:%S') }}."
           data:
             images:
-              - /config/www/cctv/front_porch_cat.jpg
-              - /config/www/cctv/front_porch_full.jpg
+              - /config/www/cctv/front_porch.jpg
             html: >
               A cat was detected on the front porch camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:front_porch_cat.jpg">
-              <br>
-              <img src="cid:front_porch_full.jpg">
+              <img src="cid:front_porch.jpg">
   
   - alias: CCTV Garage Cat Detected
     id: 8c3f1b50-b310-4f62-8fcb-e7922aa9ca3b
@@ -616,31 +472,18 @@ automation:
         entity_id: input_boolean.frigate_enabled
         state: 'on'
     action:
-      - service: camera.snapshot
-        continue_on_error: true
-        data:
-          entity_id: camera.garage
-          filename: /config/www/cctv/garage_full.jpg
-      - service: camera.snapshot
-        continue_on_error: true
-        data:
-          entity_id: image.garage_cat
-          filename: /config/www/cctv/garage_cat.jpg
-      - service: notify.cctv_email
+      - service: shell_command.garage_snapshot
         continue_on_error: true
         data:
           title: "CCTV Alarm: Garage - Cat Detected {{now().strftime('%Y-%m-%d %H:%M:%S') }}"
           message: "A cat was detected on the garage camera at {{now().strftime('%H:%M:%S') }}."
           data: 
             images:
-              - /config/www/cctv/garage_cat.jpg
-              - /config/www/cctv/garage_full.jpg     
+              - /config/www/cctv/garage.jpg 
             html: >
               A cat was detected on the garage camera at {{now().strftime('%H:%M:%S') }}.
               <br>
-              <img src="cid:garage_cat.jpg">
-              <br>
-              <img src="cid:garage_full.jpg">         
+              <img src="cid:garage.jpg">      
 
   - alias: Start Reset Timer When Frigate Disabled
     id: 891a2380-a10a-43bc-ab05-2a490d6f4f61
@@ -717,3 +560,28 @@ automation:
     action:
       - service: input_boolean.turn_on
         entity_id: input_boolean.frigate_enabled_back
+
+  - alias: Frigate Disable Front Cameras When Garage is Open
+    id: 9c8c3828-e004-4717-a212-f4e744950f60
+    trigger:
+      - platform: state
+        entity_id: sensor.elk_garage_door
+        to: Violated
+    condition:
+      - condition: state
+        entity_id: alarm_control_panel.house
+        state: disarmed
+    action:
+      - service: input_boolean.turn_off
+        entity_id: input_boolean.frigate_enabled_front
+
+  - alias: Frigate Enable Front Cameras When Garage is Closed
+    id: a43d31e1-4b1c-47c5-bd80-807a1b925910
+    trigger:
+      - platform: state
+        entity_id: sensor.elk_garage_door
+        to: Normal
+        for: "00:02:00"
+    action:
+      - service: input_boolean.turn_on
+        entity_id: input_boolean.frigate_enabled_front


### PR DESCRIPTION
# Proposed Changes

Due to new Image entities and the lack of service calls, Frigate snapshots are now being taken via shell commands.  Also added logic to disable front camera notifications when the garage door is open.
