### PR TITLE
Change Washer Idle State Value

### DIFF
--- a/packages/laundry.yaml
+++ b/packages/laundry.yaml
@@ -170,7 +170,7 @@ automation:
     trigger:
       - platform: numeric_state
         entity_id: sensor.washer_energy_power
-        below: 20
+        below: 5
         for:
           minutes: 2
     action:


### PR DESCRIPTION
# Proposed Changes

Change washer idle wattage from 20W to 5W.  This should prevent false triggers during a load.