### PR TITLE
Update Valetudo Room Handling

### DIFF
--- a/lovelace/cards/rooms/den.yaml
+++ b/lovelace/cards/rooms/den.yaml
@@ -21,11 +21,9 @@ cards:
         tap_action: none
         hold_action:
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["11"], "iterations": 1, "customOrder": true}'
-
+            room: den
         type: state-label
 
   - type: horizontal-stack

--- a/lovelace/cards/rooms/entry.yaml
+++ b/lovelace/cards/rooms/entry.yaml
@@ -22,10 +22,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["12"], "iterations": 1, "customOrder": true}'
+            room: entry
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/guest_bath.yaml
+++ b/lovelace/cards/rooms/guest_bath.yaml
@@ -37,10 +37,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["6"], "iterations": 1, "customOrder": true}'
+            room: guest_bath
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/guest_bed.yaml
+++ b/lovelace/cards/rooms/guest_bed.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["1"], "iterations": 1, "customOrder": true}'
+            room: guest_bed
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/hall.yaml
+++ b/lovelace/cards/rooms/hall.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["8"], "iterations": 1, "customOrder": true}'
+            room: hall
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/kitchen.yaml
+++ b/lovelace/cards/rooms/kitchen.yaml
@@ -45,10 +45,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["10"], "iterations": 1, "customOrder": true}'
+            room: kitchen
         type: state-label
 
   - type: horizontal-stack

--- a/lovelace/cards/rooms/master_bath.yaml
+++ b/lovelace/cards/rooms/master_bath.yaml
@@ -38,10 +38,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["2"], "iterations": 1, "customOrder": true}'
+            room: master_bath
         type: state-label
 
   - type: horizontal-stack

--- a/lovelace/cards/rooms/master_bed.yaml
+++ b/lovelace/cards/rooms/master_bed.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["5"], "iterations": 1, "customOrder": true}'
+            room: master_bed
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/office.yaml
+++ b/lovelace/cards/rooms/office.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["4"], "iterations": 1, "customOrder": true}'
+            room: office
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/server.yaml
+++ b/lovelace/cards/rooms/server.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["3"], "iterations": 1, "customOrder": true}'
+            room: server
         type: state-label
   - type: horizontal-stack
     cards:

--- a/lovelace/cards/rooms/shack.yaml
+++ b/lovelace/cards/rooms/shack.yaml
@@ -21,10 +21,9 @@ cards:
         tap_action: none
         hold_action: 
           action: call-service
-          service: mqtt.publish
+          service: script.vacuum_clean_room
           service_data:
-            topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
-            payload: '{"segment_ids": ["9"], "iterations": 1, "customOrder": true}'
+            room: shack
         type: state-label
   - type: horizontal-stack
     cards:

--- a/packages/dreame.yaml
+++ b/packages/dreame.yaml
@@ -184,6 +184,7 @@ script:
       data:
         topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
         payload: '{"segment_ids": {{ states("sensor.manual_vacuum_sequence")}}, "iterations": 1, "customOrder": true}'
+
   vacuum_run_daily_clean:
     sequence:
       - choose:
@@ -211,6 +212,13 @@ script:
                 entity_id: input_boolean.vacuum_weekday_select
       - service: input_boolean.turn_on
         entity_id: input_boolean.vacuum_cycle_initiated
+
+  vacuum_clean_room:
+    sequence:
+      - service: mqtt.publish
+        data:
+          topic: valetudo/crookshanks/MapSegmentationCapability/clean/set
+          payload: '{"segment_ids": [{{ states("sensor.valetudo_"~room~"_id")}}], "iterations": 1, "customOrder": true}'
 
 automation:
   - alias: Start Vacuum from Schedule


### PR DESCRIPTION
# Proposed Changes

Individual room handling is now done using Node-Red provided room ID sensors and a templated script.  This removes all hardcoding from HA.  When room IDs change, simply updating them in Node-Red will result in everything being correct.