### PR TITLE
Remove Deprecated Update Handlers

### DIFF
--- a/lovelace/views/system.yaml
+++ b/lovelace/views/system.yaml
@@ -436,7 +436,101 @@ cards:
                   font-size: 150%
                   left: 5%
                   transform: initial
-                tap_action: none
+                tap_action:
+                  action: fire-dom-event
+                  browser_mod:
+                    service: browser_mod.popup
+                    data:
+                      title: GitHub Updater
+                      content:
+                        type: custom:vertical-stack-in-card
+                        cards:
+                          - type: horizontal-stack
+                            cards:
+                              - type: "custom:button-card"
+                                entity: binary_sensor.git_update_ready
+                                color_type: icon
+                                state:
+                                  - value: "on"
+                                    color: rgb(228, 94, 101)
+                                  - value: "off"
+                                    color: rgb(255, 255, 255)
+                                icon: mdi:github
+                                name: Pull
+                                tap_action:
+                                  action: call-service
+                                  service: script.update_config
+
+                              - type: "custom:button-card"
+                                entity: binary_sensor.git_update_ready
+                                color_type: icon
+                                state:
+                                  - value: "on"
+                                    color: rgb(228, 94, 101)
+                                  - value: "off"
+                                    color: rgb(255, 255, 255)
+                                icon: mdi:github
+                                name: Restart
+                                tap_action:
+                                  action: call-service
+                                  service: script.update_config_restart
+
+                              - type: "custom:button-card"
+                                entity: binary_sensor.git_update_ready
+                                color_type: icon
+                                state:
+                                  - value: "on"
+                                    color: rgb(228, 94, 101)
+                                  - value: "off"
+                                    color: rgb(255, 255, 255)
+                                icon: mdi:equal
+                                name: Clear
+                                tap_action:
+                                  action: call-service
+                                  service: script.clear_config_update_flag
+
+                          - type: horizontal-stack
+                            cards:
+                              - type: "custom:button-card"
+                                color_type: icon
+                                color: rgb(255, 255, 255)
+                                icon: mdi:robot
+                                name: Automations
+                                tap_action:
+                                  action: call-service
+                                  service: automation.reload
+
+                              - type: "custom:button-card"
+                                color_type: icon
+                                color: rgb(255, 255, 255)
+                                icon: mdi:script-text
+                                name: Scripts
+                                tap_action:
+                                  action: call-service
+                                  service: script.reload
+
+                              - type: "custom:button-card"
+                                color_type: icon
+                                color: rgb(255, 255, 255)
+                                icon: mdi:tools
+                                name: Reload
+                                tap_action:
+                                  action: call-service
+                                  service: homeassistant.reload_all
+                          - type: horizontal-stack
+                            cards:
+                              - type: "custom:gap-card"
+
+                              - type: "custom:button-card"
+                                color_type: icon
+                                color: rgb(255, 255, 255)
+                                icon: mdi:web
+                                name: Tablets
+                                tap_action:
+                                  action: call-service
+                                  service: script.tablets_reload
+
+                              - type: "custom:gap-card"
                 hold_action: none
                 double_tap_action:
                   action: call-service
@@ -1354,368 +1448,7 @@ cards:
   #                                                               #
   #################################################################
   - type: vertical-stack
-    cards:
-      - type: custom:stack-in-card
-        cards:
-          - type: picture-elements
-            image: /local/lovelace/room.png
-            elements:
-              - entity: sensor.blank
-                hold-action: none
-                prefix: Updates
-                style:
-                  bottom: 20%
-                  font-size: 150%
-                  left: 5%
-                  transform: initial
-                tap_action: none
-                hold_action: none
-                type: state-label
-          - type: horizontal-stack
-            cards:
-              - type: "custom:button-card"
-                entity: binary_sensor.git_update_ready
-                color_type: icon
-                icon: mdi:github
-                state:
-                  - value: "on"
-                    color: rgb(228, 94, 101)
-                  - value: "off"
-                    color: rgb(255, 255, 255)
-                name: GitHub
-                tap_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: GitHub Updater
-                      content:
-                        type: custom:vertical-stack-in-card
-                        cards:
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:github
-                                name: Pull
-                                tap_action:
-                                  action: call-service
-                                  service: script.update_config
-
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:github
-                                name: Restart
-                                tap_action:
-                                  action: call-service
-                                  service: script.update_config_restart
-
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:equal
-                                name: Clear
-                                tap_action:
-                                  action: call-service
-                                  service: script.clear_config_update_flag
-
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:robot
-                                name: Automations
-                                tap_action:
-                                  action: call-service
-                                  service: automation.reload
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:script-text
-                                name: Scripts
-                                tap_action:
-                                  action: call-service
-                                  service: script.reload
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:tools
-                                name: Reload
-                                tap_action:
-                                  action: call-service
-                                  service: homeassistant.reload_all
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:gap-card"
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:web
-                                name: Tablets
-                                tap_action:
-                                  action: call-service
-                                  service: script.tablets_reload
-
-                              - type: "custom:gap-card"
-                hold_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: GitHub Updater
-                      content:
-                        type: custom:vertical-stack-in-card
-                        cards:
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:github
-                                name: Pull
-                                tap_action:
-                                  action: call-service
-                                  service: script.update_config
-
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:github
-                                name: Restart
-                                tap_action:
-                                  action: call-service
-                                  service: script.update_config_restart
-
-                              - type: "custom:button-card"
-                                entity: binary_sensor.git_update_ready
-                                color_type: icon
-                                state:
-                                  - value: "on"
-                                    color: rgb(228, 94, 101)
-                                  - value: "off"
-                                    color: rgb(255, 255, 255)
-                                icon: mdi:equal
-                                name: Clear
-                                tap_action:
-                                  action: call-service
-                                  service: script.clear_config_update_flag
-
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:robot
-                                name: Automations
-                                tap_action:
-                                  action: call-service
-                                  service: automation.reload
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:script-text
-                                name: Scripts
-                                tap_action:
-                                  action: call-service
-                                  service: script.reload
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:tools
-                                name: Reload
-                                tap_action:
-                                  action: call-service
-                                  service: homeassistant.reload_all
-                          - type: horizontal-stack
-                            cards:
-                              - type: "custom:gap-card"
-
-                              - type: "custom:button-card"
-                                color_type: icon
-                                color: rgb(255, 255, 255)
-                                icon: mdi:web
-                                name: Tablets
-                                tap_action:
-                                  action: call-service
-                                  service: script.tablets_reload
-
-                              - type: "custom:gap-card"
-              - type: "custom:button-card"
-                entity: sensor.hacs
-                color_type: icon
-                icon: mdi:package
-                state:
-                  - value: 0
-                    operator: ">"
-                    color: rgb(228, 94, 101)
-                  - value: 0
-                    color: rgb(255, 255, 255)
-                name: HACS
-                tap_action: 
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: HACS
-                      content:
-                        type: "custom:list-card"
-                        entity: sensor.hacs
-                        feed_attribute: repositories
-                        columns:
-                          - { field: display_name, title: "Name" }
-                          - { field: installed_version, title: "Installed" }
-                          - { field: available_version, title: "Latest" }
-                hold_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: HACS
-                      content:
-                        type: "custom:list-card"
-                        entity: sensor.hacs
-                        feed_attribute: repositories
-                        columns:
-                          - { field: display_name, title: "Name" }
-                          - { field: installed_version, title: "Installed" }
-                          - { field: available_version, title: "Latest" }
-
-              - type: "custom:button-card"
-                entity: binary_sensor.updater_addons
-                color_type: icon
-                icon: mdi:docker
-                state:
-                  - value: "on"
-                    color: rgb(228, 94, 101)
-                  - value: "off"
-                    color: rgb(255, 255, 255)
-                name: Add-Ons
-                tap_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: Add-Ons
-                      content:
-                        type: "custom:list-card"
-                        entity: sensor.supervisor_updates
-                        feed_attribute: addons
-                        columns:
-                          - { field: name, title: "Name" }
-                          - { field: version, title: "Installed" }
-                          - { field: version_latest, title: "Latest" }
-                hold_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: Add-Ons
-                      content:
-                        type: "custom:list-card"
-                        entity: sensor.supervisor_updates
-                        feed_attribute: addons
-                        columns:
-                          - { field: name, title: "Name" }
-                          - { field: version, title: "Installed" }
-                          - { field: version_latest, title: "Latest" }
-
-              - type: "custom:button-card"
-                entity: update.home_assistant_core_update
-                color_type: icon
-                icon: mdi:home-assistant
-                state:
-                  - value: "on"
-                    color: rgb(228, 94, 101)
-                  - value: "off"
-                    color: rgb(255, 255, 255)
-                name: Core
-                tap_action:
-                  action: more-info
-                hold_action:
-                  action: more-info
-
-              - type: "custom:button-card"
-                entity: binary_sensor.updater_supervisor
-                color_type: icon
-                icon: mdi:server
-                state:
-                  - value: "on"
-                    color: rgb(228, 94, 101)
-                  - value: "off"
-                    color: rgb(255, 255, 255)
-                name: Supervisor
-                tap_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: Supervisor
-                      content:
-                        type: entities
-                        show_header_toggle: false
-                        entities:
-                          - entity: sensor.supervisor_updates
-                            type: custom:multiple-entity-row
-                            name: Version
-                            show_state: false
-                            entities:
-                              - attribute: current_version
-                                name: Installed
-                              - attribute: newest_version
-                                name: Available
-                hold_action:
-                  action: fire-dom-event
-                  browser_mod:
-                    service: browser_mod.popup
-                    data:
-                      title: Supervisor
-                      content:
-                        type: entities
-                        show_header_toggle: false
-                        entities:
-                          - entity: sensor.supervisor_updates
-                            type: custom:multiple-entity-row
-                            name: Version
-                            show_state: false
-                            entities:
-                              - attribute: current_version
-                                name: Installed
-                              - attribute: newest_version
-                                name: Available
-
+    cards:      
       - type: custom:stack-in-card
         cards:
           - type: picture-elements

--- a/packages/system_status/system_status.yaml
+++ b/packages/system_status/system_status.yaml
@@ -1,52 +1,3 @@
-# device_tracker:
-#   - platform: ping
-#     hosts:
-#       core_router: !secret core_router_ip
-#       nas: !secret nas_ip
-#       hdhomerun: !secret hdhr_ip
-#       musicport: !secret musicport_ip
-#       owfs_pi: !secret owfs_pi_ip
-#       core_switch: !secret core_switch_ip
-#       poe_switch: !secret poe_switch_ip
-#       isy_994: !secret isy_ip
-#       alarm_panel: !secret alarm_panel_ip
-#       ap_front: !secret ap_front_ip
-#       ap_den: !secret ap_den_ip
-#       ap_garage: !secret ap_garage_ip
-#       ap_shed: !secret ap_shed_ip
-#       redlink: !secret redlink_ip
-#       server_ups: !secret server_ups_ip
-#       shack_ups: !secret shack_ups_ip
-#       office_ups: !secret office_ups_ip
-#       generator: !secret generator_ip
-#       rainmachine: !secret rainmachine_ip
-#       adguard: !secret adguard_ip
-
-#################################################################
-#                                                               #
-#                       Binary Sensors                          #
-#                                                               #
-#################################################################
-
-binary_sensor:
-
-  - platform: template
-    sensors:
-      # True if there's an update available for supervisor
-      updater_supervisor:
-        unique_id: 993a5a03-6340-4558-a753-a4e1ff9c5780
-        friendly_name: "Updater - Supervisor"
-        device_class: problem
-        value_template: "{{ state_attr('sensor.supervisor_updates', 'update_available') }}"
-        availability_template: "{{ (states('sensor.supervisor_updates') | int(-1)) > -1 }}"
-
-      # True if there's updates available for any addons
-      updater_addons:
-        unique_id: da31bf79-22ab-4570-bdff-a64975e106fc
-        friendly_name: "Updater - Addons"
-        device_class: problem
-        value_template: "{{ states('sensor.supervisor_updates') | int(none) > 0 }}"
-
 #################################################################
 #                                                               #
 #                           Sensors                             #
@@ -884,18 +835,6 @@ sensor:
             Error
           {% endif -%}
 
-  # Sensor to track available updates for supervisor & addons
-command_line:
-  - sensor:
-      name: Supervisor updates
-      command: 'curl http://supervisor/supervisor/info -H "Authorization: Bearer $(printenv SUPERVISOR_TOKEN)" | jq ''{"newest_version":.data.version_latest,"current_version":.data.version,"update_available":.data.update_available,"addons":[.data.addons[] | select(.update_available)]}'''
-      value_template: "{{ value_json.addons | length }}"
-      unit_of_measurement: pending update(s)
-      json_attributes:
-        - update_available
-        - newest_version
-        - current_version
-        - addons
 mqtt:
   sensor:
     - state_topic: "hass/restart"


### PR DESCRIPTION
# Proposed Changes

Remove manual update handlers.  Everything but GitHub is now handled by Home Assistant as updates and therefore is not needed on the frontend.  GitHub actions have been moved to the system monitor card.  Further updates will be mate to the system status card in future PRs.