### PR TITLE
Add Door Status Binary Sensors

### DIFF
--- a/packages/locks.yaml
+++ b/packages/locks.yaml
@@ -29,6 +29,28 @@ binary_sensor:
         delay_on:
           minutes: 5
 
+template:
+  - binary_sensor:
+    - name: Front Door Status
+      unique_id: 7c0b248c-2dc9-42f6-8e6b-6d1b53dac595
+      state: "{{ not is_state('sensor.elk_front_door', 'Normal') }}"
+      device_class: door
+    
+    - name: Back Door Status
+      unique_id: c35b578c-26c7-44af-9a22-4e58cfadef5d
+      state: "{{ not is_state('sensor.elk_back_door', 'Normal') }}"
+      device_class: door
+    
+    - name: Garage Entry Status
+      unique_id: caf86bcd-12c1-4dd3-9b9d-29e25bd81ed8
+      state: "{{ not is_state('sensor.elk_garage_entry', 'Normal') and not is_state('sensor.elk_garage_entry', 'Bypassed') }}"
+      device_class: door
+    
+    - name: Shed Door Status
+      unique_id: 60a6e39b-cd8a-4b19-8a0b-4e12b9ab4cf7
+      state: "{{ not is_state('sensor.elk_shed_door', 'Normal') }}"
+      device_class: door
+
 alert:
   front_door_lock_battery_low:
     name: Low Battery!


### PR DESCRIPTION
# Proposed Changes

Add binary sensors for each door to show open/closed status.  This is necessary because the Elk integration returns much more data in the sensor entity for each alarm input.