### PR TITLE
Update Elk Vacation Mode Handling

### DIFF
--- a/automation/alexa_routines.yaml
+++ b/automation/alexa_routines.yaml
@@ -251,6 +251,9 @@
         - condition: state
           entity_id: alarm_control_panel.house
           state: armed_away
+        - condition: state
+          entity_id: alarm_control_panel.house
+          state: armed_vacation
   action:
     - service: input_boolean.turn_on
       entity_id: input_boolean.returning_door_unlocked

--- a/automation/all_off.yaml
+++ b/automation/all_off.yaml
@@ -4,13 +4,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   action:
     - service: mqtt.publish
@@ -23,13 +27,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
     - platform: state
       entity_id: alarm_control_panel.house
@@ -83,13 +91,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   action:
     - service: light.turn_off

--- a/automation/automations.yaml
+++ b/automation/automations.yaml
@@ -4,13 +4,17 @@
     - entity_id: alarm_control_panel.house
       from: arming
       platform: state
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   condition:
     - condition: state

--- a/automation/biometric_control.yaml
+++ b/automation/biometric_control.yaml
@@ -27,10 +27,10 @@
       conditions:
         - condition: state
           entity_id: alarm_control_panel.house
-          state: armed_away
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: arming
+          state: 
+            - armed_away
+            - armed_vacation
+            - arming
   action:
     - service: lock.unlock
       entity_id: lock.garage_entry_lock

--- a/automation/blinds/common_blinds.yaml
+++ b/automation/blinds/common_blinds.yaml
@@ -15,13 +15,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
     - platform: numeric_state
       entity_id: sun.sun

--- a/automation/climate_hvac/climate_hvac.yaml
+++ b/automation/climate_hvac/climate_hvac.yaml
@@ -7,7 +7,9 @@
   condition:
     - condition: state
       entity_id: alarm_control_panel.house
-      state: armed_away
+      state: 
+        - armed_away
+        - armed_vacation
   action:
     - service: climate.set_temperature
       data:
@@ -28,7 +30,9 @@
   condition:
     - condition: state
       entity_id: alarm_control_panel.house
-      state: armed_away
+      state: 
+        - armed_away
+        - armed_vacation
   action:
     - service: climate.set_temperature
       data:
@@ -58,7 +62,7 @@
     - service: climate.set_temperature
       data:
         entity_id: climate.master_thermostat
-        target_temp_high: 75
+        target_temp_high: 74
         target_temp_low: 62
     - service: climate.set_temperature
       data:
@@ -89,7 +93,7 @@
         entity_id: 
           - climate.master_thermostat
           - climate.front_thermostat
-        target_temp_high: 75
+        target_temp_high: 74
         target_temp_low: 62
     - service: climate.set_temperature
       data:
@@ -114,6 +118,10 @@
       to: disarmed
     - platform: state
       entity_id: alarm_control_panel.house
+      from: armed_vacation
+      to: disarmed
+    - platform: state
+      entity_id: alarm_control_panel.house
       from: pending
       to: disarmed
   condition:
@@ -135,7 +143,9 @@
   trigger:
     - platform: state
       entity_id: alarm_control_panel.house
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
   action:
     - service: climate.set_temperature
       data:

--- a/automation/elk_control.yaml
+++ b/automation/elk_control.yaml
@@ -9,6 +9,8 @@
       value_template: "{{ is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
     - condition: template
       value_template: "{{ not is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: switch.turn_on
       entity_id: switch.elk_night_mode_on
@@ -26,6 +28,8 @@
       value_template: "{{ is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
     - condition: template
       value_template: "{{ not is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: switch.turn_on
       entity_id: switch.elk_night_mode_off
@@ -43,6 +47,8 @@
       value_template: "{{ is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
     - condition: template
       value_template: "{{ not is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: switch.turn_on
       entity_id: switch.elk_night_mode_off
@@ -60,6 +66,8 @@
       value_template: "{{ is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
     - condition: template
       value_template: "{{ not is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: switch.turn_on
       entity_id: switch.elk_stay_mode_off
@@ -77,6 +85,8 @@
       value_template: "{{ is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
     - condition: template
       value_template: "{{ not is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: switch.turn_on
       entity_id: switch.elk_away_mode_on
@@ -108,6 +118,8 @@
           value_template: "{{ not is_state_attr('alarm_control_panel.house', 'alarm_state', 'no_alarm_active') }}"
         - condition: template
           value_template: "{{ is_state('alarm_control_panel.house', 'armed_away') }}"
+    - condition: template
+      value_template: "{{ not is_state('alarm_control_panel.house', 'armed_vacation') }}"
   action:
     - service: input_boolean.turn_off
       entity_id:

--- a/automation/fireplace.yaml
+++ b/automation/fireplace.yaml
@@ -72,7 +72,9 @@
           state: armed_night
         - condition: state
           entity_id: alarm_control_panel.house
-          state: armed_away
+          state: 
+            - armed_away
+            - armed_vacation
   action:
     - service: switch.turn_off
       entity_id: switch.fireplace

--- a/automation/locks/back_door.yaml
+++ b/automation/locks/back_door.yaml
@@ -15,13 +15,17 @@
     - entity_id: alarm_control_panel.house
       from: arming
       platform: state
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   condition:
     - condition: state

--- a/automation/locks/front_door.yaml
+++ b/automation/locks/front_door.yaml
@@ -15,13 +15,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   condition:
     - condition: state

--- a/automation/locks/garage_entry.yaml
+++ b/automation/locks/garage_entry.yaml
@@ -15,13 +15,17 @@
     - entity_id: alarm_control_panel.house
       from: arming
       platform: state
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   condition:
     - condition: state

--- a/automation/locks/shed_door.yaml
+++ b/automation/locks/shed_door.yaml
@@ -15,13 +15,17 @@
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.house
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
     - platform: state
       entity_id: alarm_control_panel.house
@@ -35,13 +39,17 @@
     - platform: state
       entity_id: alarm_control_panel.shed
       from: arming
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
     - platform: state
       entity_id: alarm_control_panel.shed
       from: 
         - disarmed
         - armed_home
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
       for: "00:01:00"
   condition:
     - condition: state

--- a/automation/notifications.yaml
+++ b/automation/notifications.yaml
@@ -22,7 +22,9 @@
   condition:
     - condition: state
       entity_id: alarm_control_panel.house
-      state: armed_away
+      state: 
+        - armed_away
+        - armed_vacation
   action:
     - service: notify.mobile_app_shawn_n30
       data:

--- a/automation/popcorn_popper.yaml
+++ b/automation/popcorn_popper.yaml
@@ -12,7 +12,9 @@
           state: armed_night
         - condition: state
           entity_id: alarm_control_panel.house
-          state: armed_away
+          state: 
+            - armed_away
+            - armed_vacation
   action:
     - service: switch.turn_off
       entity_id: switch.popper

--- a/automation/tablet_control.yaml
+++ b/automation/tablet_control.yaml
@@ -48,7 +48,9 @@
   trigger:
     - platform: state
       entity_id: alarm_control_panel.house
-      to: armed_away
+      to: 
+        - armed_away
+        - armed_vacation
   action:
     - service: switch.turn_off
       entity_id:

--- a/automation/timer_lights.yaml
+++ b/automation/timer_lights.yaml
@@ -19,7 +19,9 @@
               state: "on"
         - condition: state
           entity_id: alarm_control_panel.house
-          state: armed_away
+          state: 
+            - armed_away
+            - armed_vacation
   action:
     - service: switch.turn_on
       continue_on_error: true
@@ -233,7 +235,9 @@
           state: "off"
         - condition: state
           entity_id: alarm_control_panel.house
-          state: armed_away
+          state: 
+            - armed_away
+            - armed_vacation
   action:
     - service: switch.turn_on
       entity_id: switch.guest_room_lamp
@@ -268,18 +272,14 @@
       event_type: automation_triggered
       event_data:
         entity_id: automation.timer_lights_on_main_weekend_holiday_am
-  condition:
-    - condition: or
-      conditions:
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: disarmed
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_away
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_home
+  condition:    
+    - condition: state
+      entity_id: alarm_control_panel.house
+      state: 
+        - disarmed
+        - armed_away
+        - armed_vacation
+        - armed_home
   action:
     - service: switch.turn_on
       continue_on_error: true
@@ -303,17 +303,13 @@
       event_data:
         entity_id: automation.timer_lights_off_main_night_mode
   condition:
-    - condition: or
-      conditions:
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: disarmed
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_away
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_home
+    - condition: state
+      entity_id: alarm_control_panel.house
+      state: 
+        - disarmed
+        - armed_away
+        - armed_vacation
+        - armed_home
   action:
     - service: switch.turn_off
       continue_on_error: true

--- a/automation/wax_warmer.yaml
+++ b/automation/wax_warmer.yaml
@@ -65,14 +65,12 @@
       entity_id: switch.wax_warmer
       to: "on"
   condition:
-    - condition: or
-      conditions:
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_night
-        - condition: state
-          entity_id: alarm_control_panel.house
-          state: armed_away
+    - condition: state
+      entity_id: alarm_control_panel.house
+      state: 
+        - armed_away
+        - armed_vacation
+        - armed_night
   action:
     - service: switch.turn_off
       entity_id: switch.wax_warmer

--- a/packages/christmas.yaml
+++ b/packages/christmas.yaml
@@ -73,13 +73,17 @@ automation:
       - platform: state
         entity_id: alarm_control_panel.house
         from: arming
-        to: armed_away
+        to: 
+          - armed_away
+          - armed_vacation
       - platform: state
         entity_id: alarm_control_panel.house
         from: 
           - disarmed
           - armed_home
-        to: armed_away
+        to: 
+          - armed_away
+          - armed_vacation
         for: "00:01:00"
       - platform: state
         entity_id: alarm_control_panel.house

--- a/packages/laundry.yaml
+++ b/packages/laundry.yaml
@@ -384,7 +384,9 @@ automation:
         conditions:
           - condition: state
             entity_id: alarm_control_panel.house
-            state: "armed_away"
+            state: 
+              - armed_away
+              - armed_vacation
           - condition: state
             entity_id: alarm_control_panel.house
             state: "armed_night"

--- a/packages/metar/metar_hou.yaml
+++ b/packages/metar/metar_hou.yaml
@@ -138,15 +138,15 @@ automation:
       - service: switch.turn_on
         entity_id: switch.houston_metar_map_power
 
-  - alias: Houston Map Off When Home and Awake
+  - alias: Houston Map Off When Not Home or Awake
     id: ceab912c-e825-4798-8fa0-ade314881bd5
     trigger:
       - platform: state
         entity_id: alarm_control_panel.house
-        to: armed_away
-      - platform: state
-        entity_id: alarm_control_panel.house
-        to: armed_night
+        to: 
+          - armed_away
+          - armed_vacation
+          - armed_night
     action:
       - service: switch.turn_off
         entity_id: switch.houston_metar_map_power

--- a/packages/metar/metar_tx.yaml
+++ b/packages/metar/metar_tx.yaml
@@ -138,15 +138,15 @@ automation:
       - service: switch.turn_on
         entity_id: switch.texas_metar_map_power
 
-  - alias: Texas Map Off When Home and Awake
+  - alias: Texas Map Off When Not Home or Awake
     id: 563d9c9c-155c-4105-b5bd-a7edbdaa5949
     trigger:
       - platform: state
         entity_id: alarm_control_panel.house
-        to: armed_away
-      - platform: state
-        entity_id: alarm_control_panel.house
-        to: armed_night
+        to: 
+          - armed_away
+          - armed_vacation
+          - armed_night
     action:
       - service: switch.turn_off
         entity_id: switch.texas_metar_map_power

--- a/packages/metar/metar_us.yaml
+++ b/packages/metar/metar_us.yaml
@@ -137,15 +137,15 @@ automation:
       - service: switch.turn_on
         entity_id: switch.us_metar_map_power
 
-  - alias: US Map Off When Home and Awake
+  - alias: US Map Off When Not Home or Awake
     id: abfd17a1-651d-4f18-846c-8f0a9fb854e3
     trigger:
       - platform: state
         entity_id: alarm_control_panel.house
-        to: armed_away
-      - platform: state
-        entity_id: alarm_control_panel.house
-        to: armed_night
+        to: 
+          - armed_away
+          - armed_vacation
+          - armed_night
     action:
       - service: switch.turn_off
         entity_id: switch.us_metar_map_power

--- a/packages/vacation_mode.yaml
+++ b/packages/vacation_mode.yaml
@@ -230,11 +230,7 @@ automation:
     - platform: state
       entity_id: alarm_control_panel.house
       from: arming
-      to: armed_away
-    condition:
-      - condition: state
-        entity_id: input_boolean.vacation_mode
-        state: "on"
+      to: armed_vacation
     action:
       service: notify.mobile_app_shawn_n30
       data:

--- a/themes/midnight.yaml
+++ b/themes/midnight.yaml
@@ -107,6 +107,7 @@ midnight:
   input-dropdown-icon-color: "var(--primary-text-color)"
   state-alarm_control_panel-disarmed-color: "#4CAF50"
   state-alarm_control_panel-armed_away-color: "#F44336"
+  state-alarm_control_panel-armed_vacation-color: "#F44336"
   state-alarm_control_panel-armed_home-color: "#F44336"
   state-alarm_control_panel-armed_night-color: "#F44336"
   state-lock-locked-color: "#ffffff"

--- a/themes/midnight_tablet.yaml
+++ b/themes/midnight_tablet.yaml
@@ -79,6 +79,7 @@ midnight-tablet:
   ha-card-background: "rgba(150, 150, 150, 0.1)"
   state-alarm_control_panel-disarmed-color: "#4CAF50"
   state-alarm_control_panel-armed_away-color: "#F44336"
+  state-alarm_control_panel-armed_vacation-color: "#F44336"
   state-alarm_control_panel-armed_home-color: "#F44336"
   state-alarm_control_panel-armed_night-color: "#F44336"
   state-lock-locked-color: "#ffffff"


### PR DESCRIPTION
# Proposed Changes

Home Assistant had an undocumented breaking change in version 2025.3.  This change added the 'armed_vacation' state to the Elk M1 integration.  While this change is for the better, automations that previously triggered when the alarm was armed in away or vacation mode (because Home Assistant reported both states as 'armed_away') will now fail to run if the panel is in state 'armed_vacation'.  This PR manually changes all instances where 'armed_away' was expected to trigger events when in vacation mode to explicitly trigger on 'armed_vacation' as well.
