### PR TITLE
Add Check for Night Mode

### DIFF
--- a/automation/climate_hvac/climate_hvac.yaml
+++ b/automation/climate_hvac/climate_hvac.yaml
@@ -175,6 +175,9 @@
     - condition: state
       entity_id: input_boolean.work_alarm_enabled
       state: "on"
+    - condition: state
+      entity_id: alarm_control_panel.house
+      state: armed_night
   action:
     - service: climate.set_temperature
       data:


### PR DESCRIPTION
# Proposed Changes

HVAC should only reset if Night Mode is active.
